### PR TITLE
Update : Improve GUI navigation and refactor feature in app

### DIFF
--- a/EasySave/Models/Data/Configuration/ApplicationSettingsService.cs
+++ b/EasySave/Models/Data/Configuration/ApplicationSettingsService.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace EasySave.Data.Configuration;
+
+/// <summary>
+///     Persists mutable application settings in appsettings.json.
+/// </summary>
+public sealed class ApplicationSettingsService
+{
+    private readonly string _appSettingsPath;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="ApplicationSettingsService" /> class.
+    /// </summary>
+    /// <param name="configFileName">Configuration file name.</param>
+    public ApplicationSettingsService(string configFileName = "appsettings.json")
+    {
+        _appSettingsPath = Path.Combine(AppContext.BaseDirectory, configFileName);
+    }
+
+    /// <summary>
+    ///     Saves the default localization value.
+    /// </summary>
+    /// <param name="localization">Localization value (for example, fr-FR or en-US).</param>
+    public void SetLocalization(string localization)
+    {
+        if (string.IsNullOrWhiteSpace(localization))
+            throw new ArgumentException("Localization cannot be empty.", nameof(localization));
+
+        Update(root => root["Localization"] = localization);
+    }
+
+    /// <summary>
+    ///     Saves the log output type.
+    /// </summary>
+    /// <param name="logType">Log type value (json or xml).</param>
+    public void SetLogType(string logType)
+    {
+        if (string.IsNullOrWhiteSpace(logType))
+            throw new ArgumentException("Log type cannot be empty.", nameof(logType));
+
+        Update(root => root["LogType"] = logType);
+    }
+
+    /// <summary>
+    ///     Updates appsettings.json by applying a mutation on the JSON root node.
+    /// </summary>
+    /// <param name="mutate">Mutation action.</param>
+    private void Update(Action<JsonObject> mutate)
+    {
+        if (mutate == null)
+            throw new ArgumentNullException(nameof(mutate));
+
+        JsonObject root;
+        if (File.Exists(_appSettingsPath))
+        {
+            var content = File.ReadAllText(_appSettingsPath);
+            root = JsonNode.Parse(content) as JsonObject ?? new JsonObject();
+        }
+        else
+        {
+            root = new JsonObject();
+        }
+
+        mutate(root);
+
+        var json = root.ToJsonString(new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        Directory.CreateDirectory(Path.GetDirectoryName(_appSettingsPath) ?? ".");
+        File.WriteAllText(_appSettingsPath, json);
+    }
+}

--- a/EasySave/ViewModels/MainWindowViewModel.BusinessSoftware.cs
+++ b/EasySave/ViewModels/MainWindowViewModel.BusinessSoftware.cs
@@ -19,7 +19,8 @@ public partial class MainWindowViewModel
     [ObservableProperty] private ObservableCollection<SelectableBusinessSoftwareItemViewModel> _addedBusinessSoftware = [];
     [ObservableProperty] private string _businessSoftwareSearchText = string.Empty;
 
-    [ObservableProperty] private string _featuresMenuLabel = "Features";
+    [ObservableProperty] private string _menuLabel = "Menu";
+    [ObservableProperty] private string _menuSettingsItemLabel = "Settings";
     [ObservableProperty] private string _manageBusinessSoftwareMenuItemLabel = "Manage Business Software";
     [ObservableProperty] private string _backButtonLabel = "Back";
     [ObservableProperty] private string _availableBusinessSoftwareTitle = "Select Business Software";
@@ -46,6 +47,11 @@ public partial class MainWindowViewModel
     public bool IsAddedSoftwareScreen => CurrentScreen == ViewScreen.AddedSoftware;
 
     /// <summary>
+    ///     Gets a value indicating whether the settings screen is visible.
+    /// </summary>
+    public bool IsSettingsScreen => CurrentScreen == ViewScreen.Settings;
+
+    /// <summary>
     ///     Gets a value indicating whether at least one available software item is selected.
     /// </summary>
     public bool CanAddSelectedBusinessSoftware => AllAvailableBusinessSoftware.Any(item => item.IsSelected);
@@ -70,7 +76,8 @@ public partial class MainWindowViewModel
     /// </summary>
     private void UpdateBusinessSoftwareUiText()
     {
-        FeaturesMenuLabel = UiText("Gui.Menu.Features", "Features");
+        MenuLabel = UiText("Gui.Menu.Root", "Menu");
+        MenuSettingsItemLabel = UiText("Gui.Menu.Settings", "Settings");
         ManageBusinessSoftwareMenuItemLabel =
             UiText("Gui.Menu.ManageBusinessSoftware", "Manage Business Software");
         BackButtonLabel = UiText("Gui.Navigation.Back", "Back");
@@ -196,6 +203,7 @@ public partial class MainWindowViewModel
         OnPropertyChanged(nameof(IsMainScreen));
         OnPropertyChanged(nameof(IsSoftwareCatalogScreen));
         OnPropertyChanged(nameof(IsAddedSoftwareScreen));
+        OnPropertyChanged(nameof(IsSettingsScreen));
     }
 
     /// <summary>
@@ -311,6 +319,7 @@ public partial class MainWindowViewModel
     public enum ViewScreen
     {
         Main,
+        Settings,
         SoftwareCatalog,
         AddedSoftware
     }

--- a/EasySave/ViewModels/MainWindowViewModel.Settings.cs
+++ b/EasySave/ViewModels/MainWindowViewModel.Settings.cs
@@ -1,0 +1,41 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace EasySave.ViewModels;
+
+public partial class MainWindowViewModel
+{
+    [ObservableProperty] private string _settingsScreenTitle = "Application Settings";
+    [ObservableProperty] private string _settingsLanguageSectionTitle = "Language";
+    [ObservableProperty] private string _settingsLogTypeSectionTitle = "Log Format";
+
+    /// <summary>
+    ///     Opens the settings screen in the current window.
+    /// </summary>
+    [RelayCommand]
+    private void OpenSettings()
+    {
+        _previousScreen = CurrentScreen;
+        SetCurrentScreen(ViewScreen.Settings);
+    }
+
+    /// <summary>
+    ///     Returns from the settings screen to the previous screen.
+    /// </summary>
+    [RelayCommand]
+    private void BackFromSettings()
+    {
+        var target = _previousScreen == ViewScreen.Settings ? ViewScreen.Main : _previousScreen;
+        SetCurrentScreen(target);
+    }
+
+    /// <summary>
+    ///     Updates settings screen labels.
+    /// </summary>
+    private void UpdateSettingsUiText()
+    {
+        SettingsScreenTitle = UiText("Gui.Settings.Screen.Title", "Application Settings");
+        SettingsLanguageSectionTitle = UiText("Gui.Settings.Section.Language", "Language");
+        SettingsLogTypeSectionTitle = UiText("Gui.Settings.Section.LogType", "Log Format");
+    }
+}

--- a/EasySave/ViewModels/MainWindowViewModel.cs
+++ b/EasySave/ViewModels/MainWindowViewModel.cs
@@ -21,6 +21,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private readonly JobService _jobService;
     private readonly LocalizationApplier _localizationApplier;
+    private readonly ApplicationSettingsService _applicationSettingsService;
     private IStorageProvider? _storageProvider;
 
     #endregion
@@ -79,9 +80,6 @@ public partial class MainWindowViewModel : ViewModelBase
     private string _windowTitle = string.Empty;
 
     [ObservableProperty]
-    private string _currentSettingsLabel = string.Empty;
-
-    [ObservableProperty]
     private string _jobsSectionTitle = string.Empty;
 
     [ObservableProperty]
@@ -134,6 +132,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         _jobService = new JobService();
         _localizationApplier = new LocalizationApplier();
+        _applicationSettingsService = new ApplicationSettingsService();
 
         // Load configuration and apply localization
         var config = ApplicationConfiguration.Load();
@@ -183,7 +182,6 @@ public partial class MainWindowViewModel : ViewModelBase
     private void UpdateUIText()
     {
         WindowTitle = UiText("Gui.Window.Title", "EasySave - Backup Manager");
-        CurrentSettingsLabel = UiText("Gui.Settings.Label", "Settings");
         JobsSectionTitle = UserInterface.Jobs_Header;
         AddSectionTitle = UserInterface.Add_Header;
         NameLabel = UserInterface.Add_PromptName;
@@ -201,6 +199,7 @@ public partial class MainWindowViewModel : ViewModelBase
         BrowseSourceLabel = UiText("Gui.Button.BrowseSource", "Browse source...");
         BrowseTargetLabel = UiText("Gui.Button.BrowseTarget", "Browse target...");
         UpdateBusinessSoftwareUiText();
+        UpdateSettingsUiText();
     }
     /// <summary>
     ///     Reads a localized value from UI resources and falls back to a default value when missing.
@@ -249,6 +248,7 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private void SetFrenchLanguage()
     {
+        _applicationSettingsService.SetLocalization("fr-FR");
         _localizationApplier.Apply("fr-FR");
         UpdateUIText();
         StatusMessage = UiText("Gui.Status.LanguageChangedFr", "Langue changee en Francais");
@@ -260,6 +260,7 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private void SetEnglishLanguage()
     {
+        _applicationSettingsService.SetLocalization("en-US");
         _localizationApplier.Apply("en-US");
         UpdateUIText();
         StatusMessage = UiText("Gui.Status.LanguageChangedEn", "Language changed to English");
@@ -275,8 +276,8 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private void SetJsonLogType()
     {
-        // Log type configuration would be persisted here if supported
-        StatusMessage = "Log type set to JSON";
+        _applicationSettingsService.SetLogType("json");
+        StatusMessage = UiText("Gui.Status.LogTypeJsonSet", "Log type set to JSON");
     }
 
     /// <summary>
@@ -285,8 +286,8 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private void SetXmlLogType()
     {
-        // Log type configuration would be persisted here if supported
-        StatusMessage = "Log type set to XML";
+        _applicationSettingsService.SetLogType("xml");
+        StatusMessage = UiText("Gui.Status.LogTypeXmlSet", "Log type set to XML");
     }
 
     #endregion

--- a/EasySave/Views/MainWindow.axaml
+++ b/EasySave/Views/MainWindow.axaml
@@ -20,52 +20,11 @@
 
     <Grid Margin="16">
         <Grid IsVisible="{Binding IsMainScreen}"
-              RowDefinitions="Auto,*,Auto,Auto"
+              RowDefinitions="*,Auto,Auto"
               ColumnDefinitions="2*,1*"
               RowSpacing="12"
               ColumnSpacing="12">
-
             <Border Grid.Row="0"
-                    Grid.ColumnSpan="2"
-                    Padding="12"
-                    CornerRadius="8"
-                    Background="{DynamicResource SecondaryBackground}"
-                    BorderBrush="{DynamicResource BorderLine}"
-                    BorderThickness="1">
-                <StackPanel Spacing="8">
-                    <Menu HorizontalAlignment="Left">
-                        <MenuItem Header="{Binding FeaturesMenuLabel}">
-                            <MenuItem Header="{Binding ManageBusinessSoftwareMenuItemLabel}"
-                                      Command="{Binding OpenBusinessSoftwareCatalogCommand}" />
-                        </MenuItem>
-                    </Menu>
-
-                    <TextBlock Text="{Binding CurrentSettingsLabel}"
-                               FontWeight="SemiBold" />
-
-                    <WrapPanel VerticalAlignment="Center">
-                        <Button Content="{Binding FrenchButtonLabel}"
-                                Command="{Binding SetFrenchLanguageCommand}"
-                                IsEnabled="{Binding IsNotBusy}"
-                                Margin="0,0,8,0"/>
-                        <Button Content="{Binding EnglishButtonLabel}"
-                                Command="{Binding SetEnglishLanguageCommand}"
-                                IsEnabled="{Binding IsNotBusy}"
-                                Margin="0,0,24,0" />
-
-                        <Button Content="{Binding JsonButtonLabel}"
-                                Command="{Binding SetJsonLogTypeCommand}"
-                                IsEnabled="{Binding IsNotBusy}"
-                                Margin="0,0,8,0" />
-                        <Button Content="{Binding XmlButtonLabel}"
-                                Command="{Binding SetXmlLogTypeCommand}"
-                                IsEnabled="{Binding IsNotBusy}"
-                                Margin="0,0,24,0" />
-                    </WrapPanel>
-                </StackPanel>
-            </Border>
-
-            <Border Grid.Row="1"
                     Grid.Column="0"
                     Padding="12"
                     CornerRadius="8"
@@ -105,10 +64,21 @@
                 </StackPanel>
             </Border>
 
-            <Border Grid.Row="1"
+            <Border Grid.Row="0"
                     Grid.Column="1"
                     Classes="main-section">
                 <StackPanel Spacing="8">
+                    <Menu HorizontalAlignment="Left">
+                        <MenuItem Header="{Binding MenuLabel}">
+                            <MenuItem Header="{Binding MenuSettingsItemLabel}"
+                                      Command="{Binding OpenSettingsCommand}" />
+                            <MenuItem Header="{Binding ManageBusinessSoftwareMenuItemLabel}"
+                                      Command="{Binding OpenBusinessSoftwareCatalogCommand}" />
+                        </MenuItem>
+                    </Menu>
+
+                    <Separator Margin="0,8,0,8" />
+
                     <TextBlock Text="{Binding AddSectionTitle}"
                                Classes="section-title" />
 
@@ -170,7 +140,7 @@
                 </StackPanel>
             </Border>
 
-            <Border Grid.Row="2"
+            <Border Grid.Row="1"
                     Grid.ColumnSpan="2"
                     Padding="12"
                     CornerRadius="8"
@@ -188,7 +158,7 @@
                 </WrapPanel>
             </Border>
 
-            <Border Grid.Row="3"
+            <Border Grid.Row="2"
                     Grid.ColumnSpan="2"
                     Padding="12"
                     CornerRadius="8"
@@ -205,6 +175,71 @@
                                  Height="18" />
                 </StackPanel>
             </Border>
+        </Grid>
+
+        <Grid IsVisible="{Binding IsSettingsScreen}"
+              RowDefinitions="Auto,*"
+              RowSpacing="12">
+            <Border Grid.Row="0"
+                    Padding="12"
+                    CornerRadius="8"
+                    Background="{DynamicResource SecondaryBackground}"
+                    BorderBrush="{DynamicResource BorderLine}"
+                    BorderThickness="1">
+                <Grid ColumnDefinitions="Auto,*"
+                      ColumnSpacing="12">
+                    <Button Grid.Column="0"
+                            Content="{Binding BackButtonLabel}"
+                            Command="{Binding BackFromSettingsCommand}" />
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding SettingsScreenTitle}"
+                               FontSize="18"
+                               FontWeight="Bold"
+                               VerticalAlignment="Center" />
+                </Grid>
+            </Border>
+
+            <Border Grid.Row="1"
+                    Padding="12"
+                    CornerRadius="8"
+                    Background="{DynamicResource SecondaryBackground}"
+                    BorderBrush="{DynamicResource BorderLine}"
+                    BorderThickness="1">
+                <StackPanel Spacing="12">
+                    <Border Classes="main-section">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{Binding SettingsLanguageSectionTitle}"
+                                       Classes="section-title" />
+                            <WrapPanel>
+                                <Button Content="{Binding FrenchButtonLabel}"
+                                        Command="{Binding SetFrenchLanguageCommand}"
+                                        IsEnabled="{Binding IsNotBusy}"
+                                        Margin="0,0,8,0" />
+                                <Button Content="{Binding EnglishButtonLabel}"
+                                        Command="{Binding SetEnglishLanguageCommand}"
+                                        IsEnabled="{Binding IsNotBusy}" />
+                            </WrapPanel>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Classes="main-section">
+                        <StackPanel Spacing="8">
+                            <TextBlock Text="{Binding SettingsLogTypeSectionTitle}"
+                                       Classes="section-title" />
+                            <WrapPanel>
+                                <Button Content="{Binding JsonButtonLabel}"
+                                        Command="{Binding SetJsonLogTypeCommand}"
+                                        IsEnabled="{Binding IsNotBusy}"
+                                        Margin="0,0,8,0" />
+                                <Button Content="{Binding XmlButtonLabel}"
+                                        Command="{Binding SetXmlLogTypeCommand}"
+                                        IsEnabled="{Binding IsNotBusy}" />
+                            </WrapPanel>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </Border>
+
         </Grid>
 
         <Grid IsVisible="{Binding IsSoftwareCatalogScreen}"

--- a/EasySave/Views/Resources/UserInterface.fr-fr.resx
+++ b/EasySave/Views/Resources/UserInterface.fr-fr.resx
@@ -171,6 +171,18 @@
     <data name="Gui.Settings.Label" xml:space="preserve">
         <value>Paramètres</value>
     </data>
+    <data name="Gui.Settings.Screen.Title" xml:space="preserve">
+        <value>Paramètres de l'application</value>
+    </data>
+    <data name="Gui.Settings.Section.Language" xml:space="preserve">
+        <value>Langue</value>
+    </data>
+    <data name="Gui.Settings.Section.LogType" xml:space="preserve">
+        <value>Type de log</value>
+    </data>
+    <data name="Gui.Settings.Hint.FutureExtension" xml:space="preserve">
+        <value>Cet écran de paramètres est prêt à accueillir de nouveaux réglages.</value>
+    </data>
     <data name="Gui.Button.French" xml:space="preserve">
         <value>Français</value>
     </data>
@@ -207,8 +219,20 @@
     <data name="Gui.Status.LanguageChangedEn" xml:space="preserve">
         <value>Langue changée en Anglais</value>
     </data>
+    <data name="Gui.Status.LogTypeJsonSet" xml:space="preserve">
+        <value>Type de log défini sur JSON</value>
+    </data>
+    <data name="Gui.Status.LogTypeXmlSet" xml:space="preserve">
+        <value>Type de log défini sur XML</value>
+    </data>
     <data name="Gui.Status.BackupStoppedByBusinessSoftware" xml:space="preserve">
         <value>Sauvegarde '{0}' arrêtée : un logiciel métier est en cours d'exécution</value>
+    </data>
+    <data name="Gui.Menu.Root" xml:space="preserve">
+        <value>Menu</value>
+    </data>
+    <data name="Gui.Menu.Settings" xml:space="preserve">
+        <value>Paramètres</value>
     </data>
     <data name="Gui.Menu.Features" xml:space="preserve">
         <value>Fonctionnalités</value>

--- a/EasySave/Views/Resources/UserInterface.resx
+++ b/EasySave/Views/Resources/UserInterface.resx
@@ -180,6 +180,18 @@
     <data name="Gui.Settings.Label" xml:space="preserve">
         <value>Settings</value>
     </data>
+    <data name="Gui.Settings.Screen.Title" xml:space="preserve">
+        <value>Application Settings</value>
+    </data>
+    <data name="Gui.Settings.Section.Language" xml:space="preserve">
+        <value>Language</value>
+    </data>
+    <data name="Gui.Settings.Section.LogType" xml:space="preserve">
+        <value>Log Type</value>
+    </data>
+    <data name="Gui.Settings.Hint.FutureExtension" xml:space="preserve">
+        <value>This settings screen is ready for future parameters.</value>
+    </data>
     <data name="Gui.Button.French" xml:space="preserve">
         <value>Français</value>
     </data>
@@ -216,8 +228,20 @@
     <data name="Gui.Status.LanguageChangedEn" xml:space="preserve">
         <value>Language changed to English</value>
     </data>
+    <data name="Gui.Status.LogTypeJsonSet" xml:space="preserve">
+        <value>Log type set to JSON</value>
+    </data>
+    <data name="Gui.Status.LogTypeXmlSet" xml:space="preserve">
+        <value>Log type set to XML</value>
+    </data>
     <data name="Gui.Status.BackupStoppedByBusinessSoftware" xml:space="preserve">
         <value>Backup '{0}' stopped: business software is running</value>
+    </data>
+    <data name="Gui.Menu.Root" xml:space="preserve">
+        <value>Menu</value>
+    </data>
+    <data name="Gui.Menu.Settings" xml:space="preserve">
+        <value>Settings</value>
     </data>
     <data name="Gui.Menu.Features" xml:space="preserve">
         <value>Features</value>

--- a/EasySave/appsettings.json
+++ b/EasySave/appsettings.json
@@ -2,5 +2,6 @@
   "Localization": "fr-FR",
   "JobConfigPath": "./config",
   "LogPath": "./log",
+  "LogType": "json",
   "BusinessSoftwareProcessNames": []
 }


### PR DESCRIPTION
# Feature: Menu Refactor and In-Window Application Settings

## Overview
This feature refactors how application settings are managed in the GUI by introducing a dedicated in-window `Settings` screen accessible from a dropdown `Menu`.

The implementation removes the previous settings area from the main screen and keeps navigation inside the same window (no popups).

## Goals Implemented
- Rename the dropdown root to `Menu`.
- Add a `Settings` entry inside the dropdown.
- Open settings in the current window only (screen switch).
- Allow users to configure:
  - application language (`French`, `English`)
  - log output format (`JSON`, `XML`)
- Keep the design extensible for future settings.
- Improve main-screen layout by moving the dropdown menu above the job creation section.
- Remove obsolete informational UI text from the settings screen.

## Functional Behavior

### 1. Main Screen Layout Changes
- The old top header layer that contained the menu and settings label was removed.
- The dropdown `Menu` is now inside the right panel (job management panel), directly above `Add Backup Job`.
- A visual separator is placed between the dropdown and the add-job form.

### 2. Dropdown Menu Content
- Root item: `Menu`
- Actions:
  - `Settings`
  - `Manage Business Software`

This structure keeps a single extensible menu entry point for current and future features.

### 3. Settings Screen (Single-Window Navigation)
- Clicking `Settings` switches the current view to the settings screen.
- No additional window is opened.
- A `Back` action returns to the previous screen.

### 4. Available Settings
- Language section:
  - `French`
  - `English`
- Log format section:
  - `JSON`
  - `XML`

Changes are applied through commands and persisted in configuration.

### 5. UI Cleanup
- The extra lower panel and hint text about future settings were removed from the settings view.
- The screen now focuses only on user-facing setting controls.

## Persistence and Configuration
- A dedicated service persists mutable settings directly in `appsettings.json`:
  - `Localization`
  - `LogType`
- This avoids scattering write logic across the ViewModel and keeps settings persistence centralized.

## Localization
All newly introduced or updated UI labels/messages are resolved through resource files (`.resx`) for English/French support.

No hardcoded user-facing string was introduced for the new settings flow.

## Architecture Notes (SOLID / MVVM)
- `MainWindowViewModel.Settings` (partial class) isolates settings-screen state and commands.
- `ApplicationSettingsService` centralizes settings persistence responsibility (SRP).
- Screen navigation is driven by `ViewScreen` state and bound visibility flags (`IsMainScreen`, `IsSettingsScreen`, etc.).
- UI remains command-based and data-bound, consistent with MVVM.

## Main Files Added
- `EasySave/Models/Data/Configuration/ApplicationSettingsService.cs`
- `EasySave/ViewModels/MainWindowViewModel.Settings.cs`

## Main Files Updated
- `EasySave/Views/MainWindow.axaml`
- `EasySave/ViewModels/MainWindowViewModel.cs`
- `EasySave/ViewModels/MainWindowViewModel.BusinessSoftware.cs`
- `EasySave/Views/Resources/UserInterface.resx`
- `EasySave/Views/Resources/UserInterface.fr-fr.resx`
- `EasySave/appsettings.json`

## Validation
- Command executed:
  - `dotnet test EasySave.sln`
- Result:
  - tests passed successfully.
