### PR TITLE
Add : Persistant Bottom in all windows

### DIFF
--- a/EasySave/Views/MainWindow.axaml
+++ b/EasySave/Views/MainWindow.axaml
@@ -18,9 +18,12 @@
         d:DesignHeight="760"
         Background="{DynamicResource PrimaryBackground}">
 
-    <Grid Margin="16">
-        <Grid IsVisible="{Binding IsMainScreen}"
-              RowDefinitions="*,Auto,Auto"
+    <Grid Margin="16"
+          RowDefinitions="*,Auto"
+          RowSpacing="12">
+        <Grid Grid.Row="0"
+              IsVisible="{Binding IsMainScreen}"
+              RowDefinitions="*,Auto"
               ColumnDefinitions="2*,1*"
               RowSpacing="12"
               ColumnSpacing="12">
@@ -158,26 +161,10 @@
                 </WrapPanel>
             </Border>
 
-            <Border Grid.Row="2"
-                    Grid.ColumnSpan="2"
-                    Padding="12"
-                    CornerRadius="8"
-                    Background="#18003D7A"
-                    BorderBrush="#33003D7A"
-                    BorderThickness="1">
-                <StackPanel Spacing="8">
-                    <TextBlock Text="{Binding StatusMessage}"
-                               TextWrapping="Wrap" />
-
-                    <ProgressBar Minimum="0"
-                                 Maximum="100"
-                                 Value="{Binding OverallProgress}"
-                                 Height="18" />
-                </StackPanel>
-            </Border>
         </Grid>
 
-        <Grid IsVisible="{Binding IsSettingsScreen}"
+        <Grid Grid.Row="0"
+              IsVisible="{Binding IsSettingsScreen}"
               RowDefinitions="Auto,*"
               RowSpacing="12">
             <Border Grid.Row="0"
@@ -242,7 +229,8 @@
 
         </Grid>
 
-        <Grid IsVisible="{Binding IsSoftwareCatalogScreen}"
+        <Grid Grid.Row="0"
+              IsVisible="{Binding IsSoftwareCatalogScreen}"
               RowDefinitions="Auto,Auto,*,Auto"
               RowSpacing="12">
             <Border Grid.Row="0"
@@ -325,7 +313,8 @@
             </Border>
         </Grid>
 
-        <Grid IsVisible="{Binding IsAddedSoftwareScreen}"
+        <Grid Grid.Row="0"
+              IsVisible="{Binding IsAddedSoftwareScreen}"
               RowDefinitions="Auto,*,Auto"
               RowSpacing="12">
             <Border Grid.Row="0"
@@ -390,5 +379,22 @@
                 </StackPanel>
             </Border>
         </Grid>
+
+        <Border Grid.Row="1"
+                Padding="12"
+                CornerRadius="8"
+                Background="#18003D7A"
+                BorderBrush="#33003D7A"
+                BorderThickness="1">
+            <StackPanel Spacing="8">
+                <TextBlock Text="{Binding StatusMessage}"
+                           TextWrapping="Wrap" />
+
+                <ProgressBar Minimum="0"
+                             Maximum="100"
+                             Value="{Binding OverallProgress}"
+                             Height="18" />
+            </StackPanel>
+        </Border>
     </Grid>
 </Window>


### PR DESCRIPTION
# Feature: Persistent Bottom Status Layer Across All Screens

## Overview
This feature ensures the bottom status/progress layer is always visible, regardless of the currently displayed screen in the application.

Before this change, the status layer was only defined inside the main screen layout.  
After the refactor, it is moved to the root window layout so it remains pinned at the bottom for every in-window screen.

## Goals Implemented
- Keep the status message visible at all times.
- Keep the global progress bar visible at all times.
- Preserve the existing status/progress bindings and visual style.
- Avoid opening additional windows or duplicating status controls across screens.

## Functional Behavior

### 1. Global Layout Refactor
- The root `Grid` now defines two rows:
  - content area (`*`)
  - persistent bottom status area (`Auto`)

### 2. Screen Content Placement
- All screen-specific grids (`Main`, `Settings`, `Software Catalog`, `Added Software`) are rendered in `Grid.Row="0"`.
- The shared status/progress layer is rendered once in `Grid.Row="1"`.

### 3. Persistent Bottom Layer
- The same status UI is reused:
  - `StatusMessage` text
  - `OverallProgress` progress bar
- It remains visible when navigating between all screens.

### 4. Duplicate Removal
- The former main-screen-only status block was removed to prevent duplicated rendering and inconsistent behavior.

## Technical Notes
- No ViewModel command logic was changed.
- No new state was added.
- Existing bindings were preserved, so runtime behavior remains consistent.

## Main File Updated
- `EasySave/Views/MainWindow.axaml`

## Validation
- Command executed:
  - `dotnet test EasySave.sln`
- Result:
  - tests passed successfully.
