### PR TITLE
Fix technical documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [English version](#english)
 
-[🔧 Accès à la documentation technique / Technical documentation here 🔧](https://easysave-amv.pages.dev/)
+[🔧 Accès à la documentation technique / Technical documentation here 🔧](https://crioschan.github.io/EasySave/)
 
 EasySave est un outil de sauvegarde automatise.
 


### PR DESCRIPTION
Updated the link to the technical documentation in the README.

![bruh](https://i.imgflip.com/akgiag.jpg)