### PR TITLE
Add : Etats en temps réel et threads safe logic

### DIFF
--- a/EasySave/Models/State/JobRunState.cs
+++ b/EasySave/Models/State/JobRunState.cs
@@ -8,20 +8,45 @@ public enum JobRunState
     /// <summary>
     ///     Job is inactive.
     /// </summary>
-    Inactive,
+    Inactive = 0,
 
     /// <summary>
     ///     Job is active.
     /// </summary>
-    Active,
+    Active = 1,
 
     /// <summary>
     ///     Job completed successfully.
     /// </summary>
-    Completed,
+    Completed = 2,
 
     /// <summary>
     ///     Job completed with errors.
     /// </summary>
-    Failed
+    Failed = 3,
+
+    /// <summary>
+    ///     Job is paused by user action.
+    /// </summary>
+    Paused = 4,
+
+    /// <summary>
+    ///     Job was explicitly stopped.
+    /// </summary>
+    Stopped = 5,
+
+    /// <summary>
+    ///     Job is waiting because priority-file scheduling blocks non-priority work.
+    /// </summary>
+    WaitingPriority = 6,
+
+    /// <summary>
+    ///     Job is waiting for large-file transfer slot availability.
+    /// </summary>
+    WaitingLargeFile = 7,
+
+    /// <summary>
+    ///     Job is paused due to business software detection.
+    /// </summary>
+    PausedBusinessSoftware = 8
 }

--- a/EasySave/Models/State/StateLogger.cs
+++ b/EasySave/Models/State/StateLogger.cs
@@ -57,7 +57,7 @@ public static class StateLogger
     {
         StateFileSingleton.Instance.UpdateState(state, s =>
         {
-            s.State = JobRunState.Failed;
+            s.State = JobRunState.Stopped;
             s.CurrentAction = "Stopped: business software running";
             s.CurrentSourcePath = null;
             s.CurrentTargetPath = null;

--- a/EasySaveTest/JobRunStateTests.cs
+++ b/EasySaveTest/JobRunStateTests.cs
@@ -29,11 +29,41 @@ public class JobRunStateTests
     }
 
     [Test]
+    public void Paused_HasCorrectValue()
+    {
+        Assert.That((int)JobRunState.Paused, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void Stopped_HasCorrectValue()
+    {
+        Assert.That((int)JobRunState.Stopped, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void WaitingPriority_HasCorrectValue()
+    {
+        Assert.That((int)JobRunState.WaitingPriority, Is.EqualTo(6));
+    }
+
+    [Test]
+    public void WaitingLargeFile_HasCorrectValue()
+    {
+        Assert.That((int)JobRunState.WaitingLargeFile, Is.EqualTo(7));
+    }
+
+    [Test]
+    public void PausedBusinessSoftware_HasCorrectValue()
+    {
+        Assert.That((int)JobRunState.PausedBusinessSoftware, Is.EqualTo(8));
+    }
+
+    [Test]
     public void AllStates_AreDefined()
     {
         var states = Enum.GetValues(typeof(JobRunState));
 
-        Assert.That(states.Length, Is.EqualTo(4));
+        Assert.That(states.Length, Is.EqualTo(9));
     }
 
     [Test]
@@ -66,6 +96,46 @@ public class JobRunStateTests
         JobRunState state = JobRunState.Failed;
 
         Assert.That(state, Is.EqualTo(JobRunState.Failed));
+    }
+
+    [Test]
+    public void CanAssignPaused()
+    {
+        JobRunState state = JobRunState.Paused;
+
+        Assert.That(state, Is.EqualTo(JobRunState.Paused));
+    }
+
+    [Test]
+    public void CanAssignStopped()
+    {
+        JobRunState state = JobRunState.Stopped;
+
+        Assert.That(state, Is.EqualTo(JobRunState.Stopped));
+    }
+
+    [Test]
+    public void CanAssignWaitingPriority()
+    {
+        JobRunState state = JobRunState.WaitingPriority;
+
+        Assert.That(state, Is.EqualTo(JobRunState.WaitingPriority));
+    }
+
+    [Test]
+    public void CanAssignWaitingLargeFile()
+    {
+        JobRunState state = JobRunState.WaitingLargeFile;
+
+        Assert.That(state, Is.EqualTo(JobRunState.WaitingLargeFile));
+    }
+
+    [Test]
+    public void CanAssignPausedBusinessSoftware()
+    {
+        JobRunState state = JobRunState.PausedBusinessSoftware;
+
+        Assert.That(state, Is.EqualTo(JobRunState.PausedBusinessSoftware));
     }
 }
 

--- a/EasySaveTest/StateFileSingletonThreadSafetyTests.cs
+++ b/EasySaveTest/StateFileSingletonThreadSafetyTests.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using EasySave.Models.State;
+using EasySave.Models.Utils;
+
+namespace EasySaveTest;
+
+/// <summary>
+///     Verifies state store thread-safety and non-destructive re-initialization behavior.
+/// </summary>
+[NonParallelizable]
+public class StateFileSingletonThreadSafetyTests
+{
+    [Test]
+    public void Initialize_CalledTwiceOnSamePath_DoesNotResetExistingRuntimeState()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"EasySaveState_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            StateFileSingleton.Instance.Initialize(root);
+            var state = StateFileSingleton.Instance.GetOrCreate(50001, "Feature02.Job");
+
+            StateFileSingleton.Instance.UpdateState(state, s =>
+            {
+                s.State = JobRunState.Active;
+                s.ProgressPercent = 42;
+                s.CurrentAction = "initial_run";
+            });
+
+            StateFileSingleton.Instance.Initialize(root);
+            var reloaded = StateFileSingleton.Instance.GetOrCreate(50001, "Feature02.Job");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(reloaded.State, Is.EqualTo(JobRunState.Active));
+                Assert.That(reloaded.ProgressPercent, Is.EqualTo(42));
+                Assert.That(reloaded.CurrentAction, Is.EqualTo("initial_run"));
+            });
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Test]
+    public void UpdateState_InParallel_KeepsStateFileValidAndConsistent()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"EasySaveState_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+
+        try
+        {
+            StateFileSingleton.Instance.Initialize(root);
+            var state = StateFileSingleton.Instance.GetOrCreate(50002, "Feature02.ConcurrentJob");
+
+            Parallel.For(0, 250, i =>
+            {
+                StateFileSingleton.Instance.UpdateState(state, s =>
+                {
+                    s.State = JobRunState.Active;
+                    s.ProgressPercent = i % 100;
+                    s.RemainingFiles = 250 - i;
+                    s.CurrentAction = "parallel_update";
+                });
+            });
+
+            var statePath = Path.Combine(root, "state.json");
+            var json = File.ReadAllText(statePath);
+            var parsed = JsonSerializer.Deserialize<List<BackupJobState>>(json, JsonFile.Options);
+            var target = parsed?.FirstOrDefault(x => x.JobId == 50002);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(parsed, Is.Not.Null);
+                Assert.That(target, Is.Not.Null);
+                Assert.That(target!.CurrentAction, Is.EqualTo("parallel_update"));
+                Assert.That(target.ProgressPercent, Is.GreaterThanOrEqualTo(0));
+                Assert.That(target.ProgressPercent, Is.LessThan(100));
+            });
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}


### PR DESCRIPTION
# État temps réel thread-safe

## Contexte
Cette PR implémente **uniquement la Feature 02** du plan du livrable 3 :  
rendre la gestion de l'état temps réel robuste pour une exécution concurrente et préparer les futurs comportements runtime v3.

## Problème avant cette PR
- `StateFileSingleton` était conçu pour un scénario séquentiel.
- Aucune protection thread-safe n'encadrait les accès concurrents à `_states` et `state.json`.
- Un appel à `Initialize(...)` pouvait réinitialiser l'état en cours.
- `JobRunState` ne disposait pas des statuts runtime nécessaires aux usages v3.
- Un arrêt métier était classé comme `Failed` au lieu d'un état d'arrêt explicite.

## Objectif
- Sécuriser les écritures/lectures d'état en contexte concurrent.
- Étendre les statuts d'exécution pour supporter les transitions runtime v3.
- Conserver la compatibilité avec le comportement existant.

## Changements réalisés

### 1) Extension des statuts runtime
**Fichier modifié**
- `EasySave/Models/State/JobRunState.cs`

**Ajouts**
- `Paused`
- `Stopped`
- `WaitingPriority`
- `WaitingLargeFile`
- `PausedBusinessSoftware`

**Compatibilité**
- Les valeurs existantes (`Inactive=0`, `Active=1`, `Completed=2`, `Failed=3`) sont conservées.

### 2) Sécurisation thread-safe du state store
**Fichier modifié**
- `EasySave/Models/State/StateFileSingleton.cs`

**Améliorations clés**
- Ajout d'un verrou interne (`_sync`) pour sérialiser toutes les mutations d'état.
- Ajout d'un garde d'initialisation (`_isInitialized`) pour empêcher l'usage avant `Initialize(...)`.
- `Initialize(...)` devient non destructif sur le même chemin :
- recharge l'existant si fichier présent,
- synchronise les jobs configurés sans écraser les états runtime déjà actifs,
- persiste atomiquement un JSON valide.
- `Update(...)`, `GetOrCreate(...)`, `UpdateState(...)` passent sous verrou avec cohérence des écritures.

### 3) Ajustement sémantique de l'arrêt métier
**Fichier modifié**
- `EasySave/Models/State/StateLogger.cs`

**Changement**
- `SetStateStoppedByBusinessSoftware(...)` positionne `JobRunState.Stopped` (au lieu de `Failed`).

## Tests

### Tests modifiés
- `EasySaveTest/JobRunStateTests.cs`
- Ajout des assertions sur les nouveaux états et leurs valeurs.

### Tests ajoutés
- `EasySaveTest/StateFileSingletonThreadSafetyTests.cs`
- `Initialize_CalledTwiceOnSamePath_DoesNotResetExistingRuntimeState`
- `UpdateState_InParallel_KeepsStateFileValidAndConsistent`

## Validation
Commande exécutée :
- `dotnet test EasySave.sln`

Résultat :
- `EasyLogTest` : OK
- `EasySaveTest` : OK (222 tests)

## Fichiers impactés
- `EasySave/Models/State/JobRunState.cs`
- `EasySave/Models/State/StateFileSingleton.cs`
- `EasySave/Models/State/StateLogger.cs`
- `EasySaveTest/JobRunStateTests.cs`
- `EasySaveTest/StateFileSingletonThreadSafetyTests.cs`

## Checklist PR
- [x] Scope limité à la Feature 02
- [x] État temps réel sécurisé en concurrence
- [x] Statuts runtime v3 ajoutés
- [x] Tests unitaires mis à jour/ajoutés
- [x] Suite de tests complète verte
