### PR TITLE
fix(socket): Le serveur considéré comme toujours disponible

### DIFF
--- a/EasySave.Server/EasySave.Server.csproj
+++ b/EasySave.Server/EasySave.Server.csproj
@@ -5,7 +5,6 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RootNamespace>EasySave.Log</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/EasySave.Server/Server.cs
+++ b/EasySave.Server/Server.cs
@@ -5,18 +5,18 @@ using System.Text.Json;
 using EasyLog;
 using EasySave.Log.Model;
 
-namespace Server;
+namespace EasySave.Server;
 
 /// <summary>
-///     Main class for the UDP server that receives messages.
+///     Main class for the TCP server that receives messages.
 /// </summary>
 public static class Server
 {
     // Logger used for logging messages
     private static AbstractLogger<LogEntry> _logger;
 
-    // UDP client for receiving messages
-    private static UdpClient _udpServer;
+    // TCP listener for receiving messages
+    private static TcpListener _tcpServer;
 
     /// <summary>
     ///     Main entry point of the application.
@@ -32,43 +32,68 @@ public static class Server
         else
             _logger = new JsonLogger<LogEntry>("./logs/"); // Initialize JSON logger
 
-        Console.WriteLine("Server is listening for UDP messages...");
+        Console.WriteLine("Server is listening for TCP messages...");
 
         // Infinite loop to listen for client messages
-        while (true) ListenForClients(); // Listen for incoming messages
+        while (true)
+        {
+            ListenForClients(); // Listen for incoming messages
+        }
     }
 
     /// <summary>
-    ///     Initializes the UDP server by binding to a specified port.
+    ///     Initializes the TCP server by binding to a specified port.
     /// </summary>
     private static void StartServer()
     {
-        _udpServer = new UdpClient(5000); // Bind to port 5000
+        _tcpServer = new TcpListener(IPAddress.Any, 5000); // Bind to port 5000
+        _tcpServer.Start(); // Start listening for TCP connections
     }
 
     /// <summary>
-    ///     Listens for clients to receive UDP messages.
+    ///     Listens for clients to receive TCP messages.
     /// </summary>
     private static void ListenForClients()
     {
-        var remoteEndPoint = new IPEndPoint(IPAddress.Any, 0); // Remote endpoint for receiving messages
-        var buffer = new byte[1024]; // Buffer for storing received data
-
         try
         {
-            // Receive asynchronously and get the remote endpoint info
-            var receivedResult = _udpServer.Receive(ref remoteEndPoint);
-            var data = Encoding.ASCII.GetString(receivedResult); // Convert received data to string
+            using var client = _tcpServer.AcceptTcpClient(); // Accept incoming TCP client connection
+            using var networkStream = client.GetStream(); // Get the network stream for the client
 
-            // Deserialize the received data into a log entry
-            var entry = JsonSerializer.Deserialize<LogEntry>(data);
-            if (entry != null)
+            var lengthBuffer = new byte[4]; // Buffer to read the length of the incoming message
+
+            try
             {
-                entry.ClientIPAddress = remoteEndPoint.Address.ToString(); // Add client IP address to log entry
-                var logMessage = FormatLogMessage(entry.ToString(), remoteEndPoint); // Format log message
-                Console.WriteLine(logMessage); // Display the message in the console
+                // Read the first 4 bytes to get the length of the incoming data
+                int bytesRead = networkStream.Read(lengthBuffer, 0, lengthBuffer.Length);
+                if (bytesRead == 4) // Make sure we read the correct amount
+                {
+                    int dataLength = BitConverter.ToInt32(lengthBuffer, 0); // Convert bytes to integer
 
-                Log(entry); // Log the entry
+                    var dataBuffer = new byte[dataLength]; // Create a buffer for the incoming data
+                    bytesRead = networkStream.Read(dataBuffer, 0, dataLength); // Read the actual data
+
+                    var data = Encoding.ASCII.GetString(dataBuffer, 0, bytesRead); // Convert received data to string
+
+                    // Deserialize the received data into a log entry
+                    var entry = JsonSerializer.Deserialize<LogEntry>(data);
+                    if (entry != null)
+                    {
+                        entry.ClientIPAddress = ((IPEndPoint)client.Client.RemoteEndPoint).Address.ToString(); // Add client IP address to log entry
+                        var logMessage = FormatLogMessage(entry.ToString(), (IPEndPoint)client.Client.RemoteEndPoint); // Format log message
+                        Console.WriteLine(logMessage); // Display the message in the console
+
+                        Log(entry); // Log the entry
+                    }
+                }
+                else
+                {
+                    Console.WriteLine("Failed to read the length of the incoming data.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Exception: {ex.Message}"); // Handle exceptions and display the error
             }
         }
         catch (Exception ex)

--- a/EasySave/Models/Logger/NetworkLog.cs
+++ b/EasySave/Models/Logger/NetworkLog.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -7,7 +8,7 @@ using EasySave.Data.Configuration;
 namespace EasySave.Models.Logger;
 
 /// <summary>
-///     Singleton class for logging over a network using UDP.
+///     Singleton class for logging over a network using TCP.
 /// </summary>
 public sealed class NetworkLog
 {
@@ -15,7 +16,7 @@ public sealed class NetworkLog
     private static readonly Lazy<NetworkLog> instance = new(() => new NetworkLog());
     private IPEndPoint _endpoint; // Endpoint for sending logs
 
-    private UdpClient? _udpClient; // UDP client for sending log messages
+    private TcpClient? _tcpClient; // TCP client for sending log messages
     public EventHandler? OnConnect; // Event triggered when the connection is established
     public EventHandler? OnDisconnect; // Event triggered when the connection is lost
 
@@ -34,7 +35,7 @@ public sealed class NetworkLog
     public static NetworkLog Instance => instance.Value;
 
     /// <summary>
-    ///     Creates a UDP socket for logging.
+    ///     Creates a TCP socket for logging.
     /// </summary>
     public void CreateSocket()
     {
@@ -49,8 +50,10 @@ public sealed class NetworkLog
                     IPAddress.Parse(ApplicationConfiguration.Load().EasySaveServerIp),
                     ApplicationConfiguration.Load().EasySaveServerPort);
 
-                _udpClient = new UdpClient(); // Instantiate the UDP client
+                _tcpClient = new TcpClient(); // Instantiate the TCP client
+                _tcpClient.Connect(_endpoint); // Establish the TCP connection
                 OnConnectEvent(); // Trigger the connect event
+                
                 Console.WriteLine("Socket created and ready to use.");
             }
             catch (Exception e)
@@ -62,16 +65,16 @@ public sealed class NetworkLog
     }
 
     /// <summary>
-    ///     Closes the UDP socket if it is open.
+    ///     Closes the TCP socket if it is open.
     /// </summary>
     public void CloseSocket()
     {
         try
         {
-            if (_udpClient != null)
+            if (_tcpClient != null)
             {
-                _udpClient.Close(); // Close the socket
-                _udpClient = null; // Clear the reference
+                _tcpClient.Close(); // Close the socket
+                _tcpClient = null; // Clear the reference
                 Console.WriteLine("Socket closed.");
             }
         }
@@ -81,6 +84,11 @@ public sealed class NetworkLog
         }
     }
 
+    private readonly JsonSerializerOptions _options = new JsonSerializerOptions
+    {
+        WriteIndented = false // No indentation for compact messages
+    };
+    
     /// <summary>
     ///     Sends a log message to the defined endpoint.
     /// </summary>
@@ -91,17 +99,28 @@ public sealed class NetworkLog
         lock (this) // Ensure thread safety
         {
             // Serialize the message to JSON and convert it to byte array
-            var data = Encoding.ASCII.GetBytes(JsonSerializer.Serialize(message, new JsonSerializerOptions
-            {
-                WriteIndented = false // No indentation for compact messages
-            }));
+            var data = Encoding.ASCII.GetBytes(JsonSerializer.Serialize(message, _options));
 
             try
             {
-                _udpClient?.Send(data, data.Length, _endpoint); // Send the log message
+                if (_tcpClient is { Connected: true })
+                {
+                    NetworkStream stream = _tcpClient.GetStream();
+                    // Send the length of the data first
+                    var lengthBytes = BitConverter.GetBytes(data.Length);
+                    stream.Write(lengthBytes, 0, lengthBytes.Length); // Send length (4 bytes)
+            
+                    // Then send the actual data
+                    stream.Write(data, 0, data.Length); // Send log entry data
+                }
+                else
+                {
+                    throw new InvalidOperationException("TCP client is not connected.");
+                }
             }
-            catch
+            catch (Exception e)
             {
+                Console.WriteLine(e.Message);
                 // On failure to send, attempt to recreate the socket
                 CreateSocket();
             }


### PR DESCRIPTION
Cette PR vient résoudre le problème qui continuait d'afficher que le serveur était disponible pour la centralisation des logs, alors qu'absolument pas.
C'est donc une migration de UDP vers TCP. Les logs sont assez rapide pour ne pas y avoir de problème en TCP.

![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2F736x%2F53%2F3d%2F89%2F533d891d1f54a2481d5fb14d31ec7f29.jpg&f=1&nofb=1&ipt=4eec475803d549a55dc8e59d1c7c3dcb665d64cce55be5d80b533ddb669a68df)